### PR TITLE
Update to 0.3.16

### DIFF
--- a/rpm/grilo-plugins.spec
+++ b/rpm/grilo-plugins.spec
@@ -1,9 +1,9 @@
 Name:       grilo-plugins
 Summary:    Plugins for the Grilo framework
-Version:    0.3.15
+Version:    0.3.16
 Release:    1
 License:    LGPLv2+
-URL:        https://wiki.gnome.org/Projects/Grilo
+URL:        https://github.com/sailfishos/grilo-plugins
 Source0:    %{name}-%{version}.tar.bz2
 BuildRequires:  meson >= 0.37.0
 BuildRequires:  lua >= 5.3.0
@@ -19,7 +19,7 @@ BuildRequires:  pkgconfig(gobject-2.0) >= 2.44
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  pkgconfig(libarchive)
 BuildRequires:  pkgconfig(libmediaart-2.0)
-BuildRequires:  pkgconfig(libsoup-2.4)
+BuildRequires:  pkgconfig(libsoup-3.0)
 BuildRequires:  pkgconfig(sqlite3)
 BuildRequires:  pkgconfig(totem-plparser) >= 3.4.1
 BuildRequires:  pkgconfig(tracker-sparql-3.0)
@@ -118,13 +118,6 @@ Requires: %{name} = %{version}-%{release}
 %description -n grilo-plugin-dleyna
 A Grilo plugin for browsing UPnP/DLNA servers.
 
-%package -n grilo-plugin-opensubtitles
-Summary:  Grilo plugin - OpenSubtitles Provider
-Requires: %{name} = %{version}-%{release}
-
-%description -n grilo-plugin-opensubtitles
-A Grilo plugin that gets a list of subtitles for a video.
-
 %package -n grilo-plugin-tmdb
 Summary:  Grilo plugin - TMDb
 Requires: %{name} = %{version}-%{release}
@@ -155,57 +148,40 @@ rm -rf $RPM_BUILD_ROOT%{_libdir}/pkgconfig/grilo-plugins-0.3.pc
 %find_lang %{name}
 
 %files -f %{name}.lang
-%defattr(-,root,root,-)
 %license COPYING
 
 %files -n grilo-plugin-filesystem
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrlfilesystem.so
 
 %files -n grilo-plugin-flickr
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrlflickr.so
 
 %files -n grilo-plugin-podcasts
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrlpodcasts.so
 
 %files -n grilo-plugin-shoutcast
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrlshoutcast.so
 
 %files -n grilo-plugin-metadata-store
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrlmetadatastore.so
 
 %files -n grilo-plugin-gravatar
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrlgravatar.so
 
 %files -n grilo-plugin-tracker
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrltracker3.so
 
 %files -n grilo-plugin-localmetadata
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrllocalmetadata.so
 
 %files -n grilo-plugin-raitv
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrlraitv.so
 
 %files -n grilo-plugin-magnatune
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrlmagnatune.so
 
 %files -n grilo-plugin-dleyna
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrldleyna.so
 
-%files -n grilo-plugin-opensubtitles
-%defattr(-,root,root,-)
-%{_libdir}/grilo-0.3/libgrlopensubtitles.so
-
 %files -n grilo-plugin-tmdb
-%defattr(-,root,root,-)
 %{_libdir}/grilo-0.3/libgrltmdb.so


### PR DESCRIPTION
Build with libsoup3. Drop opensubtitles support (needs libsoup2.4). Switch to use packaging URL. Remove not needed defattr from spec.